### PR TITLE
Update readme examples to ensure compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ npm install thingiverse-js
 const thingiverse = require('thingiverse-js');
 const token = 'abcdefgh12345';
 
-thingiverse('users/me', { token }).then(res => {
+thingiverse('users/me', { token: token }).then(res => {
   console.log('My location is "%s" on Thingiverse', res.body.location);
   return thingiverse.patch(`users/${res.body.name}`, {
-    token,
+    token: token,
     body: { location: 'New Caprica' }
   });
 }).then(res => {


### PR DESCRIPTION
Thingiverse API seems to have changed since this library was released. access token should be placed in request body under the key "token".